### PR TITLE
fix: remove repo_total_size_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ BUGFIXES
 --------
  - Rename the column in the view `ccp_table_size` from `size_bytes` to just `bytes`. Allows for the underlying metric in the pgMonitor project to be more consistent with the metric name (`ccp_table_size_bytes` vs `ccp_table_size_size_bytes`). Also makes it consistent with other size measurement column names.
  - Allow pg_stat_statements to be installed in any user defined schema if those metrics are being used.
+ - Removed the pgBackRest metric `repo_total_size_bytes` from the `ccp_backrest_last_info` view. When block incremental backups are enabled it is no longer possible to gather this metric from the pgBackRest info output. Since this is often enabled now, this metric is no longer regularly available.
 
 
 2.0.0

--- a/sql/views/backrest_views.sql
+++ b/sql/views/backrest_views.sql
@@ -82,7 +82,6 @@ CREATE VIEW @extschema@.ccp_backrest_last_info AS
     , a.backup_data->'database'->>'repo-key' AS repo
     , a.backup_data->>'type' AS backup_type
     , a.backup_data->'info'->'repository'->>'delta' AS repo_backup_size_bytes
-    , a.backup_data->'info'->'repository'->>'size' AS repo_total_size_bytes
     , (a.backup_data->'timestamp'->>'stop')::bigint - (a.backup_data->'timestamp'->>'start')::bigint AS backup_runtime_seconds
     , CASE
        WHEN a.backup_data->>'error' = 'true' THEN 1


### PR DESCRIPTION
Remove the metric repo_total_size_bytes since it is no longer possible to collect when block incremental backups are enabled in pgbackrest